### PR TITLE
Refactor submodule callables

### DIFF
--- a/megatron/core/models/gpt/fine_grained_schedule.py
+++ b/megatron/core/models/gpt/fine_grained_schedule.py
@@ -275,9 +275,9 @@ def build_layer_schedule_plan(layer, event, chunk_state, comp_stream, com_stream
     # Create nodes for different operations in the layer
     # Each node type has a predefined name that determines its memory strategy
     attn = TransformerLayerNode(comp_stream, event, common_state, attn_callable, True, ctx, name="attn")
-    dispatch = TransformerLayerNode(comp_stream, event, common_state, dispatch_callable, True, ctx, name="dispatch")
+    dispatch = TransformerLayerNode(com_stream, event, common_state, dispatch_callable, True, ctx, name="dispatch")
     mlp = TransformerLayerNode(comp_stream, event, common_state, mlp_callable, True, ctx, name="mlp")
-    combine = TransformerLayerNode(comp_stream, event, common_state, combine_callable, True, ctx, name="combine")
+    combine = TransformerLayerNode(com_stream, event, common_state, combine_callable, True, ctx, name="combine")
     
     return TransformerLayerSchedulePlan(attn, dispatch, mlp, combine)
 

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -33,6 +33,12 @@ def stream_acquire_context(stream, event):
     finally:
         event.record(stream)
 
+class FakeScheduleNode:
+    def forward(self, inputs):
+        return inputs
+
+    def backward(self, outgrads):
+        return outgrads
 
 class ScheduleNode:
     """Base node for fine-grained scheduling.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -472,37 +472,8 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
 
         return output, context
 
-    def _callable_wrapper(
-        self, is_forward, func, stream, event, *args, skip_detach=False, **kwargs
-    ):
-        """
-        Wraps a function call so that it waits for a given CUDA event before
-        proceeding and then runs the function on a specified CUDA stream.
-        """
-        torch.cuda.nvtx.range_push(func.__name__)
-        event.wait(stream)
-        with torch.cuda.stream(stream):
-            outputs = func(*args, **kwargs)
-        event.record(stream)
-        if skip_detach:
-            torch.cuda.nvtx.range_pop()
-            return outputs
-        detached_output_tensors = []
-        if not is_forward:
-            torch.cuda.nvtx.range_pop()
-            return outputs, detached_output_tensors
-        for tensor in outputs:
-            if tensor is None:
-                detached_output_tensors.append(None)
-            elif tensor.dtype.is_floating_point:
-                detached_output_tensors.append(tensor.detach().requires_grad_(True))
-            else:
-                detached_output_tensors.append(tensor.detach())
-        torch.cuda.nvtx.range_pop()
-        return outputs, detached_output_tensors
-
     def _submodule_attention_forward(
-        self,
+        self, 
         hidden_states,
         attention_mask=None,
         inference_params=None,
@@ -541,17 +512,17 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
         return hidden_states
 
     def _submodule_attention_router_compound_forward(
-        self,
-        hidden_states,
-        attention_mask=None,
-        inference_params=None,
-        rotary_pos_emb=None,
-        rotary_pos_cos=None,
-        rotary_pos_sin=None,
-        attention_bias=None,
-        packed_seq_params=None,
-        sequence_len_offset=None,
-    ):
+            self, 
+            hidden_states,
+            attention_mask=None,
+            inference_params=None,
+            rotary_pos_emb=None,
+            rotary_pos_cos=None,
+            rotary_pos_sin=None,
+            attention_bias=None,
+            packed_seq_params=None,
+            sequence_len_offset=None,
+        ):
         """
         Performs a combined forward pass that includes self-attention and MLP routing logic.
         """
@@ -564,35 +535,21 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
             rotary_pos_sin,
             attention_bias,
             packed_seq_params,
-            sequence_len_offset,
-        )
+            sequence_len_offset)
 
         pre_mlp_layernorm_output = self.pre_mlp_layernorm(hidden_states)
         probs, routing_map = self.mlp.router(pre_mlp_layernorm_output)
-        tokens_per_expert = self.mlp.token_dispatcher.meta_prepare(
-            pre_mlp_layernorm_output, probs, routing_map
-        )
-        permutated_local_input_tokens = self.mlp.token_dispatcher.dispatch_preprocess(
-            pre_mlp_layernorm_output, routing_map
-        )
+        tokens_per_expert = self.mlp.token_dispatcher.meta_prepare(pre_mlp_layernorm_output, probs, routing_map)
+        permutated_local_input_tokens = self.mlp.token_dispatcher.dispatch_preprocess(pre_mlp_layernorm_output, routing_map)
 
-        outputs = [
-            hidden_states,
-            pre_mlp_layernorm_output,
-            tokens_per_expert,
-            permutated_local_input_tokens,
-            probs,
-        ]
-        return tuple(outputs)
-
-    def _submodule_dispatch_forward(self, permutated_local_input_tokens):
+        return hidden_states, pre_mlp_layernorm_output, tokens_per_expert, permutated_local_input_tokens
+    
+    def _submodule_dispatch_forward(self, tokens):
         """
         Dispatches tokens to the appropriate experts based on the router output.
         """
-        global_input_tokens = self.mlp.token_dispatcher.dispatch_all_to_all(
-            permutated_local_input_tokens
-        )
-        return [global_input_tokens]
+        output_tokens = self.mlp.token_dispatcher.dispatch_all_to_all(tokens)
+        return output_tokens
 
     def _submodule_dense_forward(self, hidden_states):
         residual = hidden_states
@@ -607,8 +564,8 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
         )
 
         return output
-
-    def _submodule_moe_forward(self, dispatched_input, tokens_per_expert, hidden_states):
+    
+    def _submodule_moe_forward(self, dispatched_input, hidden_states, tokens_per_expert):
         """
         Performs a forward pass for the MLP submodule, including both expert-based
         and optional shared-expert computations.
@@ -621,19 +578,11 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
             shared_expert_output = self.mlp.shared_experts(hidden_states)
         return expert_output, shared_expert_output, mlp_bias
 
-    def _submodule_combine_forward(self, hidden_states):
-        return [self.mlp.token_dispatcher.combine_all_to_all(hidden_states)]
-
-    def _submodule_post_combine_forward(
-        self, expert_output, shared_expert_output, mlp_bias, residual
-    ):
-        """
-        Re-combines the expert outputs (and optional shared_expert_output) into the same order
-        as the original input tokens, applying any required bias.
-        """
-        output = self.mlp.token_dispatcher.combine_postprocess(expert_output)
+    def _submodule_combine_forward(self, output, shared_expert_output, residual, mlp_bias=None):
+        output = self.mlp.token_dispatcher.combine_all_to_all(output)
+        output = self.mlp.token_dispatcher.combine_postprocess(output)
         if shared_expert_output is not None:
-            output += shared_expert_output
+            output = output + shared_expert_output
         mlp_output_with_bias = (output, mlp_bias)
         with self.bias_dropout_add_exec_handler():
             hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
@@ -645,74 +594,19 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
 
         return output
 
-    def _submodule_attention_backward(
-        self, hidden_states, pre_mlp_layernorm_output, detached_inputs
-    ):
-        pre_mlp_layernorm_output.backward(detached_inputs[1].grad)
-        hidden_states.backward(detached_inputs[0].grad)
-
-    def _submodule_attention_router_compound_backward(
-        self,
-        hidden_states,
-        pre_mlp_layernorm_output,
-        tokens_per_expert,
-        permutated_local_input_tokens,
-        probs,
-        detached_inputs,
-    ):
-        permutated_local_input_tokens.backward(detached_inputs[3].grad)
-        probs.backward(detached_inputs[4].grad)
-        # tokens_per_expert.backward(detached_inputs[2].grad)
-        pre_mlp_layernorm_output.backward(detached_inputs[1].grad)
-        hidden_states.backward(detached_inputs[0].grad)
-
-    def _submodule_dispatch_backward(self, global_input_tokens, detached_inputs):
-        global_input_tokens.backward(detached_inputs[0].grad)
-
-    def _submodule_dense_backward(self, output, detached_inputs):
-        output.backward(detached_inputs[0].grad)
-
-    def _submodule_moe_backward(
-        self, expert_output, shared_expert_output, mlp_bias, detached_inputs
-    ):
-        expert_output.backward(detached_inputs[0].grad)
-        shared_expert_output.backward(detached_inputs[1].grad)
-        if mlp_bias is not None:
-            mlp_bias.backward(detached_inputs[2].grad)
-
-    def _submodule_combine_backward(self, hidden_states, detached_inputs):
-        hidden_states.backward(detached_inputs[0].grad)
-
-    def _submodule_post_combine_backward(self, output, output_grad):
-        output.backward(output_grad)
-
-    def _submodule_attention_router_compound_dgrad(self):
-        raise NotImplementedError("Not implemented")
-
     def _submodule_attention_router_compound_dw(self):
         self.self_attention.backward_dw()
-        # raise NotImplementedError("Not implemented")
-
-    def _submodule_dispatch_dgrad(self):
-        raise NotImplementedError("Not implemented")
-
-    def _submodule_mlp_dgrad(self):
-        raise NotImplementedError("Not implemented")
 
     def _submodule_mlp_dw(self):
         self.mlp.backward_dw()
-        # raise NotImplementedError("Not implemented")
-
-    def _submodule_combine_dgrad(self):
-        raise NotImplementedError("Not implemented")
 
     def _submodule_identity_forward(self, *args):
         return args
 
-    def _submodule_identity_backward(self, *args):
-        pass
+    def _submodule_check_func(self, *args):
+        raise NotImplementedError("The submodule 'dw' function should not be called for dense layer.")
 
-    def get_submodule_callables(self):
+    def get_submodule_callables(self, chunk_state):
         """
         Returns a dictionary of submodule callables for the transformer layer.
         """
@@ -722,64 +616,49 @@ class TransformerLayer(MegatronModule, BaseTransformerLayer):
             if isinstance(self.mlp, MoELayer):
                 return func
             return default_func
-
         attention_func = get_func_with_default(
             self._submodule_attention_router_compound_forward, self._submodule_attention_forward
         )
-        attention_backward_func = get_func_with_default(
-            self._submodule_attention_router_compound_backward, self._submodule_attention_backward
+        attention_dw_func = get_func_with_default(
+            self._submodule_attention_router_compound_dw, self._submodule_check_func
         )
         dispatch_func = get_func_with_default(
             self._submodule_dispatch_forward, self._submodule_identity_forward
         )
-        dispatch_backward_func = get_func_with_default(
-            self._submodule_dispatch_backward, self._submodule_identity_backward
-        )
         mlp_func = get_func_with_default(self._submodule_moe_forward, self._submodule_dense_forward)
-        mlp_backward_func = get_func_with_default(
-            self._submodule_moe_backward, self._submodule_dense_backward
+        mlp_dw_func = get_func_with_default(
+            self._submodule_mlp_dw, self._submodule_check_func
         )
         combine_func = get_func_with_default(
             self._submodule_combine_forward, self._submodule_identity_forward
         )
-        combine_backward_func = get_func_with_default(
-            self._submodule_combine_backward, self._submodule_identity_backward
-        )
-        post_combine_func = get_func_with_default(
-            self._submodule_post_combine_forward, self._submodule_identity_forward
-        )
-        post_combine_backward_func = get_func_with_default(
-            self._submodule_post_combine_backward, self._submodule_identity_backward
-        )
+        def attn_wrapper(hidden_states):
+            return attention_func(
+                hidden_states, 
+                attention_mask = chunk_state.attention_mask,
+                attention_bias = chunk_state.attention_bias,
+                inference_params = chunk_state.inference_params,
+                packed_seq_params = chunk_state.packed_seq_params,
+                sequence_len_offset = chunk_state.sequence_len_offset,
+                rotary_pos_emb = chunk_state.rotary_pos_emb,
+                rotary_pos_cos = chunk_state.rotary_pos_cos,
+                rotary_pos_sin = chunk_state.rotary_pos_sin,
+            )
 
         callables = TransformerLayerSubmoduleCallables(
             attention=SubmoduleCallables(
-                forward=partial(self._callable_wrapper, True, attention_func, skip_detach=True),
-                backward=partial(self._callable_wrapper, False, attention_backward_func),
-                # dgrad=partial(self._callable_wrapper, False,self._submodule_attention_router_compound_dgrad),
-                dw=partial(
-                    self._callable_wrapper, False, self._submodule_attention_router_compound_dw
-                ),
+                forward=attn_wrapper,
+                dw=attention_dw_func,
             ),
             dispatch=SubmoduleCallables(
-                forward=partial(self._callable_wrapper, True, dispatch_func),
-                backward=partial(self._callable_wrapper, False, dispatch_backward_func),
-                # dgrad=partial(self._callable_wrapper, False, self._submodule_dispatch_dgrad),
+                forward=dispatch_func,
             ),
             mlp=SubmoduleCallables(
-                forward=partial(self._callable_wrapper, True, mlp_func),
-                backward=partial(self._callable_wrapper, False, mlp_backward_func),
-                # dgrad=partial(self._callable_wrapper, False, self._submodule_mlp_dgrad),
-                dw=partial(self._callable_wrapper, False, self._submodule_mlp_dw),
+                forward=mlp_func,
+                dw=mlp_dw_func,
             ),
             combine=SubmoduleCallables(
-                forward=partial(self._callable_wrapper, True, combine_func),
-                backward=partial(self._callable_wrapper, False, combine_backward_func),
-                # dgrad=partial(self._callable_wrapper, False, self._submodule_combine_dgrad),
-            ),
-            post_combine=SubmoduleCallables(
-                forward=partial(self._callable_wrapper, True, post_combine_func),
-                backward=partial(self._callable_wrapper, False, post_combine_backward_func),
+                forward=combine_func,
             ),
         )
         return callables

--- a/megatron/core/transformer/utils.py
+++ b/megatron/core/transformer/utils.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from functools import lru_cache
 from operator import itemgetter
+from functools import partial
 from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple, Union
 
 import torch
@@ -202,11 +203,10 @@ class SubmoduleCallables:
     Holds references to forward, dgrad, and dw (weight-grad) callables
     for a particular submodule.
     """
-
-    forward: Optional[Callable] = None
-    backward: Optional[Callable] = None
-    dgrad: Optional[Callable] = None
-    dw: Optional[Callable] = None
+    def raise_not_implemented(name: str):
+        raise NotImplementedError(f"{name} not implemented.")
+    forward: Optional[Callable] = partial(raise_not_implemented, "forward")
+    dw: Optional[Callable] = partial(raise_not_implemented, "dw")
 
 
 @dataclass
@@ -220,7 +220,6 @@ class TransformerLayerSubmoduleCallables:
     dispatch: SubmoduleCallables
     mlp: SubmoduleCallables
     combine: SubmoduleCallables
-    post_combine: SubmoduleCallables
 
     def as_array(self):
-        return [self.attention, self.dispatch, self.mlp, self.combine, self.post_combine]
+        return [self.attention, self.dispatch, self.mlp, self.combine]


### PR DESCRIPTION
* Remove post_combine in transformer layer
* Remove attention/dispatch/mlp/combine class in fine_grained_schedules.py
* Refactored to use `layer.get_submodule_callables` instead of `layer._submodule_xxx` in build_schedule
  * Move per_batch_state into callable wrappers and use forward_ctx for abstraction
  * Added postprocess callables for tensor detachment

* Correctness: https://wandb.ai/hwinf_dcm/1f1b-a2a-overlap-correctness/panel/j5lyqmhfc?nw=nwuserpingtianl
* Performance: https://wandb.ai/hwinf_dcm/1f1b-a2a-overlap-DSv3-test?nw=nwuserpingtianl