### PR TITLE
Refactoring backward_dw and add assertions

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, NoReturn
 
 import torch
 from torch import Tensor

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -847,6 +847,22 @@ class SelfAttention(Attention):
 
         return query, key, value
 
+    def backward_dw(self) -> NoReturn:
+        """Execute weight update operations"""
+        try:
+            self._backward_qkv_proj()
+            self._backward_output_proj()
+        except Exception as e:
+            raise RuntimeError(f"Error in SelfAttention backward_dw: {str(e)}")
+
+    def _backward_qkv_proj(self):
+        """Update weights for QKV projection layer"""
+        self.linear_qkv.backward_dw()
+
+    def _backward_output_proj(self):
+        """Update weights for output projection layer"""
+        self.linear_proj.backward_dw()
+
 
 class CrossAttention(Attention):
     """Cross-attention layer class

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -155,8 +155,11 @@ class MLP(MegatronModule):
         return sharded_state_dict
 
     def backward_dw(self):
-        self.linear_fc2.backward_dw()
-        self.linear_fc1.backward_dw()
+        try:
+            self.linear_fc2.backward_dw()
+            self.linear_fc1.backward_dw()
+        except Exception as e:
+            raise RuntimeError(f"MLP backward_dw execution failed: {str(e)}") from e
 
 
 # pylint: disable=missing-function-docstring

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -3,7 +3,7 @@
 
 import math
 from dataclasses import dataclass
-from typing import Union
+from typing import Union, NoReturn
 
 import torch
 
@@ -436,12 +436,28 @@ class MLASelfAttention(MultiLatentAttention):
 
         return query, key, value
 
-    def backward_dw(self):
+    def backward_dw(self) -> NoReturn:
+        """Execute weight update operations"""
+        try:
+            self._backward_kv_proj()
+            self._backward_q_proj()
+            self._backward_output_proj()
+        except Exception as e:
+            raise RuntimeError(f"Error in MLASelfAttention backward_dw: {str(e)}")
+
+    def _backward_kv_proj(self):
+        """Update weights for KV projection layers"""
         self.linear_kv_up_proj.backward_dw()
         self.linear_kv_down_proj.backward_dw()
+
+    def _backward_q_proj(self):
+        """Update weights for Q projection layers"""
         if self.config.q_lora_rank is None:
             self.linear_q_proj.backward_dw()
         else:
             self.linear_q_down_proj.backward_dw()
             self.linear_q_up_proj.backward_dw()
+
+    def _backward_output_proj(self):
+        """Update weights for output projection layer"""
         self.linear_proj.backward_dw()

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -869,13 +869,6 @@ def validate_args(args, defaults={}):
             'combined 1F1B is only supported with pipeline model parallelism'
         assert args.num_layers_per_virtual_pipeline_stage is not None or args.num_virtual_stages_per_pipeline_rank is not None, \
             'virtual pipeline parallel should be enabled for combined 1F1B'
-        
-        # Handle p2p communication overlap
-        if args.overlap_p2p_comm:
-            # Combined 1F1B overlaps also overlaps p2p communication, 
-            # however, it uses the code path of args.overlap_p2p_comm == False
-            # Todo: @Youngeun to check the schedule.py since the flag may cause some confusions.
-            args.overlap_p2p_comm = False
 
         # Additional requirements for ep_a2a recipe
         if args.combined_1f1b_recipe == 'ep_a2a':

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -886,15 +886,12 @@ def validate_args(args, defaults={}):
                 'Combined 1f1b recipe ep_a2a is only supported with alltoall token dispatcher'
             
             # Disable recomputation as it conflicts with combined 1F1B's memory management
-            recomputation_params = {
-                'recompute_activations': args.recompute_activations,
-                'recompute_granularity': args.recompute_granularity,
-                'recompute_method': args.recompute_method,
-                'recompute_num_layers': args.recompute_num_layers
-            }
-            for param_name, param_value in recomputation_params.items():
-                if param_value is not None and param_value is not False:
-                    raise ValueError(f'{param_name} is not supported when combined_1f1b_recipe is ep_a2a')
+            assert args.recompute_granularity != 'full', \
+                'recompute_granularity must not be full when combined_1f1b_recipe is ep_a2a'
+            assert args.recompute_method is None, \
+                'recompute_method must be None when combined_1f1b_recipe is ep_a2a'
+            assert args.recompute_num_layers is None, \
+                'recompute_num_layers must be None when combined_1f1b_recipe is ep_a2a'
             
             # Disable shared expert overlap as it conflicts with ep_a2a
             assert not args.moe_shared_expert_overlap, \
@@ -1341,7 +1338,7 @@ def _add_logging_args(parser):
                        help='Report to tensorboard interval.')
     group.add_argument('--tensorboard-queue-size', type=int, default=1000,
                        help='Size of the tensorboard queue for pending events '
-                       'and summaries before one of the 'add' calls forces a '
+                       'and summaries before one of the "add" calls forces a '
                        'flush to disk.')
     group.add_argument('--log-timers-to-tensorboard', action='store_true',
                        help='If set, write timers to tensorboard.')


### PR DESCRIPTION
- Add error exception for backward_dw
- Add assertions in arguments.py
  - --combined-1f1b must be used with pp and vpp;
  - ep-a2a recipe must be used with EP and alltoall dispatcher;
  - full recomputation must be disabled;
  - shared-expert-overlap must be disabled;